### PR TITLE
annotate hes12

### DIFF
--- a/chunks/scaffold_17.gff3
+++ b/chunks/scaffold_17.gff3
@@ -5853,7 +5853,7 @@ scaffold_17	StringTie	exon	9581779	9581869	.	+	.	ID=exon-235759;Parent=TCONS_000
 scaffold_17	StringTie	exon	9582088	9583392	.	+	.	ID=exon-235760;Parent=TCONS_00057996;exon_number=4;gene_id=XLOC_022166;transcript_id=TCONS_00057996
 scaffold_17	StringTie	transcript	9582088	9583397	.	+	.	ID=TCONS_00057997;Parent=XLOC_022166;gene_id=XLOC_022166;oId=TCONS_00057997;transcript_id=TCONS_00057997;tss_id=TSS46366
 scaffold_17	StringTie	exon	9582088	9583397	.	+	.	ID=exon-235761;Parent=TCONS_00057997;exon_number=1;gene_id=XLOC_022166;transcript_id=TCONS_00057997
-scaffold_17	StringTie	gene	9598040	9601741	.	+	.	ID=XLOC_022167;gene_id=XLOC_022167;oId=TCONS_00057998;transcript_id=TCONS_00057998;tss_id=TSS46367
+scaffold_17	StringTie	gene	9598040	9601741	.	+	.	ID=XLOC_022167;gene_id=XLOC_022167;oId=TCONS_00057998;transcript_id=TCONS_00057998;tss_id=TSS46367;name=hes12;annotator=Nikolaos Papadopoulos/Wanninger lab;
 scaffold_17	StringTie	transcript	9598040	9601741	.	+	.	ID=TCONS_00057998;Parent=XLOC_022167;gene_id=XLOC_022167;oId=TCONS_00057998;transcript_id=TCONS_00057998;tss_id=TSS46367
 scaffold_17	StringTie	exon	9598040	9598212	.	+	.	ID=exon-235762;Parent=TCONS_00057998;exon_number=1;gene_id=XLOC_022167;transcript_id=TCONS_00057998
 scaffold_17	StringTie	exon	9599933	9600028	.	+	.	ID=exon-235763;Parent=TCONS_00057998;exon_number=2;gene_id=XLOC_022167;transcript_id=TCONS_00057998


### PR DESCRIPTION
NCBI sequence of hes12 from [Gazave _et al._](https://evodevojournal.biomedcentral.com/articles/10.1186/2041-9139-5-29) was mapped to the v021 transcriptome via Jekely BLAST webserver; best hit was confirmed to be member of the HES family via reverse [BLAST search](https://github.com/user-attachments/files/16891852/DK0WD80J013-Alignment.txt) on NCBI.

Other relevant resources: [Hes/Hey gene family phylogeny](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3396596/)