### PR TITLE
Update scaffold_12.gff3-00

### DIFF
--- a/chunks/scaffold_12.gff3-00
+++ b/chunks/scaffold_12.gff3-00
@@ -9776,7 +9776,7 @@ scaffold_12	StringTie	exon	16258600	16259381	.	+	.	ID=exon-171029;Parent=TCONS_0
 scaffold_12	StringTie	gene	16266153	16266633	.	+	.	ID=XLOC_016181;gene_id=XLOC_016181;oId=TCONS_00044472;transcript_id=TCONS_00044472;tss_id=TSS35564
 scaffold_12	StringTie	transcript	16266153	16266633	.	+	.	ID=TCONS_00044472;Parent=XLOC_016181;gene_id=XLOC_016181;oId=TCONS_00044472;transcript_id=TCONS_00044472;tss_id=TSS35564
 scaffold_12	StringTie	exon	16266153	16266633	.	+	.	ID=exon-185549;Parent=TCONS_00044472;exon_number=1;gene_id=XLOC_016181;transcript_id=TCONS_00044472
-scaffold_12	StringTie	gene	16302309	16337692	.	+	.	ID=XLOC_014850;gene_id=XLOC_014850;oId=TCONS_00040964;transcript_id=TCONS_00040964;tss_id=TSS32801
+scaffold_12	StringTie	gene	16302309	16337692	.	+	.	ID=XLOC_014850;gene_id=XLOC_014850;oId=TCONS_00040964;transcript_id=TCONS_00040964;tss_id=TSS32801;name=thyroid receptor;annotator=Samuel Tambunan/Schneider lab
 scaffold_12	StringTie	transcript	16302309	16337690	.	+	.	ID=TCONS_00040962;Parent=XLOC_014850;gene_id=XLOC_014850;oId=TCONS_00040962;transcript_id=TCONS_00040962;tss_id=TSS32801
 scaffold_12	StringTie	exon	16302309	16302760	.	+	.	ID=exon-171065;Parent=TCONS_00040962;exon_number=1;gene_id=XLOC_014850;transcript_id=TCONS_00040962
 scaffold_12	StringTie	exon	16304053	16304091	.	+	.	ID=exon-171066;Parent=TCONS_00040962;exon_number=2;gene_id=XLOC_014850;transcript_id=TCONS_00040962


### PR DESCRIPTION
PdumBase of Schneider Lab showed the best hit. 

This gene is also been mentioned and tested in this preprint paper. Guillaume Holzer. Origin of thyroid hormone signalling in metazoans and implications in their metamorphosis. Molecular biology. Ecole normale supérieure de lyon - ENS LYON, 2015. English. ⟨NNT : 2015ENSL1062⟩. ⟨tel-01398254⟩