### PR TITLE
Update scaffold_2.gff3-05

### DIFF
--- a/chunks/scaffold_2.gff3-05
+++ b/chunks/scaffold_2.gff3-05
@@ -2180,7 +2180,7 @@ scaffold_2	StringTie	exon	81049288	81049438	.	+	.	ID=exon-274213;Parent=TCONS_00
 scaffold_2	StringTie	gene	81071127	81071603	.	+	.	ID=XLOC_033385;gene_id=XLOC_033385;oId=TCONS_00081888;transcript_id=TCONS_00081888;tss_id=TSS66263
 scaffold_2	StringTie	transcript	81071127	81071603	.	+	.	ID=TCONS_00081888;Parent=XLOC_033385;gene_id=XLOC_033385;oId=TCONS_00081888;transcript_id=TCONS_00081888;tss_id=TSS66263
 scaffold_2	StringTie	exon	81071127	81071603	.	+	.	ID=exon-317164;Parent=TCONS_00081888;exon_number=1;gene_id=XLOC_033385;transcript_id=TCONS_00081888
-scaffold_2	StringTie	gene	81087465	81087934	.	+	.	ID=XLOC_033386;gene_id=XLOC_033386;oId=TCONS_00081889;transcript_id=TCONS_00081889;tss_id=TSS66264
+scaffold_2	StringTie	gene	81087465	81087934	.	+	.	ID=XLOC_033386;gene_id=XLOC_033386;oId=TCONS_00081889;transcript_id=TCONS_00081889;tss_id=TSS66264, name=protostome specific methyltransferase - psmt;annotator=Rannyele Ribeiro/Ozpolat lab
 scaffold_2	StringTie	transcript	81087465	81087934	.	+	.	ID=TCONS_00081889;Parent=XLOC_033386;gene_id=XLOC_033386;oId=TCONS_00081889;transcript_id=TCONS_00081889;tss_id=TSS66264
 scaffold_2	StringTie	exon	81087465	81087934	.	+	.	ID=exon-317165;Parent=TCONS_00081889;exon_number=1;gene_id=XLOC_033386;transcript_id=TCONS_00081889
 scaffold_2	StringTie	gene	81092654	81098802	.	-	.	ID=XLOC_027910;gene_id=XLOC_027910;oId=TCONS_00075050;transcript_id=TCONS_00075050;tss_id=TSS59824


### PR DESCRIPTION
_psmt_ - protostome specific methyltransferase is a novel gene discovered from _Platynereis dumerilii_’s transcriptome of coelomic contents (Ribeiro et al 2024). _psmt_ sequence was mapped to the v021 transcriptome via Jekely BLAST web server, and correspondent XLOC was confirmed via blastn against the genome (_Platynereis dumerilii_ (Dumeril's clam worm) - GCA_026936325.1 (EMBL_pdum_1.0). 

Ribeiro, R.P., Null, R.W., Ozpolat, D.B. Sex-biased gene expression precedes sexual dimorphism in the agonadal annelid _Platynereis dumerilii_. bioRxiv 2024.06.12.598746; https://doi.org/10.1101/2024.06.12.598746