### PR TITLE
annotate FMRFamide

### DIFF
--- a/chunks/scaffold_10.gff3-01
+++ b/chunks/scaffold_10.gff3-01
@@ -12026,7 +12026,7 @@ scaffold_10	StringTie	transcript	46145389	46149568	.	+	.	ID=TCONS_00027079;Paren
 scaffold_10	StringTie	exon	46145389	46145680	.	+	.	ID=exon-114179;Parent=TCONS_00027079;exon_number=1;gene_id=XLOC_009490;transcript_id=TCONS_00027079
 scaffold_10	StringTie	exon	46146866	46147072	.	+	.	ID=exon-114180;Parent=TCONS_00027079;exon_number=2;gene_id=XLOC_009490;transcript_id=TCONS_00027079
 scaffold_10	StringTie	exon	46147640	46149568	.	+	.	ID=exon-114181;Parent=TCONS_00027079;exon_number=3;gene_id=XLOC_009490;transcript_id=TCONS_00027079
-scaffold_10	StringTie	gene	46177513	46198523	.	+	.	ID=XLOC_009491;gene_id=XLOC_009491;oId=TCONS_00027080;transcript_id=TCONS_00027080;tss_id=TSS21596
+scaffold_10	StringTie	gene	46177513	46198523	.	+	.	ID=XLOC_009491;gene_id=XLOC_009491;oId=TCONS_00027080;transcript_id=TCONS_00027080;tss_id=TSS21596;name=FMRFamide;annotator=Sanja Jasek/Jekely lab
 scaffold_10	StringTie	transcript	46177513	46198523	.	+	.	ID=TCONS_00027080;Parent=XLOC_009491;gene_id=XLOC_009491;oId=TCONS_00027080;transcript_id=TCONS_00027080;tss_id=TSS21596
 scaffold_10	StringTie	exon	46177513	46177657	.	+	.	ID=exon-114182;Parent=TCONS_00027080;exon_number=1;gene_id=XLOC_009491;transcript_id=TCONS_00027080
 scaffold_10	StringTie	exon	46180294	46180470	.	+	.	ID=exon-114183;Parent=TCONS_00027080;exon_number=2;gene_id=XLOC_009491;transcript_id=TCONS_00027080

--- a/chunks/scaffold_14.gff3
+++ b/chunks/scaffold_14.gff3
@@ -4323,7 +4323,7 @@ scaffold_14	StringTie	exon	7858880	7859445	.	+	.	ID=exon-205239;Parent=TCONS_000
 scaffold_14	StringTie	exon	7859483	7860288	.	+	.	ID=exon-205240;Parent=TCONS_00049857;exon_number=2;gene_id=XLOC_018721;transcript_id=TCONS_00049857
 scaffold_14	StringTie	transcript	7858983	7860295	.	+	.	ID=TCONS_00049858;Parent=XLOC_018721;gene_id=XLOC_018721;oId=TCONS_00049858;transcript_id=TCONS_00049858;tss_id=TSS39899
 scaffold_14	StringTie	exon	7858983	7860295	.	+	.	ID=exon-205241;Parent=TCONS_00049858;exon_number=1;gene_id=XLOC_018721;transcript_id=TCONS_00049858
-scaffold_14	StringTie	gene	7858983	7967287	.	-	.	ID=XLOC_019091;gene_id=XLOC_019091;oId=TCONS_00050966;transcript_id=TCONS_00050966;tss_id=TSS40731
+scaffold_14	StringTie	gene	7858983	7967287	.	-	.	ID=XLOC_019091;gene_id=XLOC_019091;oId=TCONS_00050966;transcript_id=TCONS_00050966;tss_id=TSS40731;name=RYamide;annotator=Sanja Jasek/Jekely lab
 scaffold_14	StringTie	transcript	7858983	7967287	.	-	.	ID=TCONS_00050965;Parent=XLOC_019091;gene_id=XLOC_019091;oId=TCONS_00050965;transcript_id=TCONS_00050965;tss_id=TSS40731
 scaffold_14	StringTie	exon	7858983	7860286	.	-	.	ID=exon-209645;Parent=TCONS_00050965;exon_number=1;gene_id=XLOC_019091;transcript_id=TCONS_00050965
 scaffold_14	StringTie	exon	7868064	7868196	.	-	.	ID=exon-209646;Parent=TCONS_00050965;exon_number=2;gene_id=XLOC_019091;transcript_id=TCONS_00050965


### PR DESCRIPTION
Sequence from [1] was blasted againt Pdum transcriptome 021, and hit was confirmed by reverse BLAST search on NCBI.

[1] Conzelmann, M., Williams, E.A., Krug, K. et al. The neuropeptide complement of the marine annelid Platynereis dumerilii. BMC Genomics 14, 906 (2013). https://doi.org/10.1186/1471-2164-14-906