### PR TITLE
Annotation: dbh (dopamine beta-hydroxylase)

### DIFF
--- a/chunks/scaffold_6.gff3-01
+++ b/chunks/scaffold_6.gff3-01
@@ -4892,7 +4892,7 @@ scaffold_6	StringTie	transcript	30600108	30601676	.	+	.	ID=TCONS_00132240;Parent
 scaffold_6	StringTie	exon	30600108	30601054	.	+	.	ID=exon-499597;Parent=TCONS_00132240;exon_number=1;gene_id=XLOC_055366;transcript_id=TCONS_00132240
 scaffold_6	StringTie	exon	30601177	30601676	.	+	.	ID=exon-499598;Parent=TCONS_00132240;exon_number=2;gene_id=XLOC_055366;transcript_id=TCONS_00132240
 scaffold_6	StringTie	gene	30600108	30639157	.	-	.	ID=XLOC_056341;gene_id=XLOC_056341;oId=TCONS_00135236;transcript_id=TCONS_00135236;tss_id=TSS109191
-scaffold_6	StringTie	transcript	30600108	30639155	.	-	.	ID=TCONS_00135235;Parent=XLOC_056341;gene_id=XLOC_056341;oId=TCONS_00135235;transcript_id=TCONS_00135235;tss_id=TSS109191
+scaffold_6	StringTie	transcript	30600108	30639155	.	-	.	ID=TCONS_00135235;Parent=XLOC_056341;gene_id=XLOC_056341;oId=TCONS_00135235;transcript_id=TCONS_00135235;tss_id=TSS109191;name=dbh (dopamine beta-hydroxylase);annotator=Benedikt R. Duerr (ORCID:0000-0003-4052-9577) / Jekely lab
 scaffold_6	StringTie	exon	30600108	30601679	.	-	.	ID=exon-511548;Parent=TCONS_00135235;exon_number=1;gene_id=XLOC_056341;transcript_id=TCONS_00135235
 scaffold_6	StringTie	exon	30602952	30603105	.	-	.	ID=exon-511549;Parent=TCONS_00135235;exon_number=2;gene_id=XLOC_056341;transcript_id=TCONS_00135235
 scaffold_6	StringTie	exon	30605397	30605524	.	-	.	ID=exon-511550;Parent=TCONS_00135235;exon_number=3;gene_id=XLOC_056341;transcript_id=TCONS_00135235


### PR DESCRIPTION
Annotation: *dbh* (dopamine beta-hydroxylase)

**Gene:** *dbh* (dopamine beta-hydroxylase)
**Gene Nomenclature**: [HGNC](https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:2689)
**NCBI GeneBank ID:** [KJ855061.1](https://www.ncbi.nlm.nih.gov/nuccore/KJ855061.1/) (mRNA, complete cds)

**Annotated XLOC:** XLOC_056341
**Annotation Process:**
- Obtained mRNA cds from NCBI
- Mapped to P. dum. transcriptome assembly v021 using BLASTn (Jékely Lab): [Results](https://jekelylab.ex.ac.uk/blast/a92baa31-d9bf-4654-8723-f634622173ce) 
- Best hit (TCONS_00135235 XLOC_056341) > blastx on NCBI > confirmed

**Comments:** /