### PR TITLE
annotate foxA

### DIFF
--- a/chunks/scaffold_7.gff3-01
+++ b/chunks/scaffold_7.gff3-01
@@ -2896,7 +2896,7 @@ scaffold_7	StringTie	gene	24256167	24259748	.	+	.	ID=XLOC_059273;gene_id=XLOC_05
 scaffold_7	StringTie	transcript	24256167	24259748	.	+	.	ID=TCONS_00141864;Parent=XLOC_059273;gene_id=XLOC_059273;oId=TCONS_00141864;transcript_id=TCONS_00141864;tss_id=TSS114622
 scaffold_7	StringTie	exon	24256167	24259011	.	+	.	ID=exon-535549;Parent=TCONS_00141864;exon_number=1;gene_id=XLOC_059273;transcript_id=TCONS_00141864
 scaffold_7	StringTie	exon	24259059	24259748	.	+	.	ID=exon-535550;Parent=TCONS_00141864;exon_number=2;gene_id=XLOC_059273;transcript_id=TCONS_00141864
-scaffold_7	StringTie	gene	24261242	24269189	.	-	.	ID=XLOC_060337;gene_id=XLOC_060337;oId=TCONS_00145367;transcript_id=TCONS_00145367;tss_id=TSS117355
+scaffold_7	StringTie	gene	24261242	24269189	.	-	.	ID=XLOC_060337;gene_id=XLOC_060337;oId=TCONS_00145367;transcript_id=TCONS_00145367;tss_id=TSS117355;name=foxA;annotator=Roman P Kostyuchenko/Dept Embryology St.Petersburg University
 scaffold_7	StringTie	transcript	24261242	24269189	.	-	.	ID=TCONS_00145367;Parent=XLOC_060337;gene_id=XLOC_060337;oId=TCONS_00145367;transcript_id=TCONS_00145367;tss_id=TSS117355
 scaffold_7	StringTie	exon	24261242	24265449	.	-	.	ID=exon-549743;Parent=TCONS_00145367;exon_number=1;gene_id=XLOC_060337;transcript_id=TCONS_00145367
 scaffold_7	StringTie	exon	24268970	24269189	.	-	.	ID=exon-549744;Parent=TCONS_00145367;exon_number=2;gene_id=XLOC_060337;transcript_id=TCONS_00145367


### PR DESCRIPTION
NCBI sequence of foxA was mapped (form 1) to the v0.2.1 transcriptome via Jekely BLAST web server; best hit was confirmed to the member of the Fox (Forkhead box protein B) family via reserve BLAST search on NCBI

[1] https://pubmed.ncbi.nlm.nih.gov/30566266/