### PR TITLE
Annotation: Ras-GTPase-activating protein-binding-like protein

### DIFF
--- a/chunks/scaffold_2.gff3-04
+++ b/chunks/scaffold_2.gff3-04
@@ -8890,7 +8890,7 @@ scaffold_2	StringTie	exon	73453264	73453626	.	+	.	ID=exon-272427;Parent=TCONS_00
 scaffold_2	StringTie	gene	73471242	73472007	.	+	.	ID=XLOC_033261;gene_id=XLOC_033261;oId=TCONS_00081762;transcript_id=TCONS_00081762;tss_id=TSS66138
 scaffold_2	StringTie	transcript	73471242	73472007	.	+	.	ID=TCONS_00081762;Parent=XLOC_033261;gene_id=XLOC_033261;oId=TCONS_00081762;transcript_id=TCONS_00081762;tss_id=TSS66138
 scaffold_2	StringTie	exon	73471242	73472007	.	+	.	ID=exon-317038;Parent=TCONS_00081762;exon_number=1;gene_id=XLOC_033261;transcript_id=TCONS_00081762
-scaffold_2	StringTie	gene	73473885	73482292	.	+	.	ID=XLOC_025966;gene_id=XLOC_025966;oId=TCONS_00068049;transcript_id=TCONS_00068049;tss_id=TSS54395
+scaffold_2	StringTie	gene	73473885	73482292	.	+	.	ID=XLOC_025966;gene_id=XLOC_025966;oId=TCONS_00068049;transcript_id=TCONS_00068049;tss_id=TSS54395;name=Ras-GTPase-activating protein-binding-like protein;annotator=Marlen Brodbeck (ORCID:0009-0006-6502-2560) / Jekely lab
 scaffold_2	StringTie	transcript	73473885	73482292	.	+	.	ID=TCONS_00068049;Parent=XLOC_025966;gene_id=XLOC_025966;oId=TCONS_00068049;transcript_id=TCONS_00068049;tss_id=TSS54395
 scaffold_2	StringTie	exon	73473885	73474052	.	+	.	ID=exon-272428;Parent=TCONS_00068049;exon_number=1;gene_id=XLOC_025966;transcript_id=TCONS_00068049
 scaffold_2	StringTie	exon	73475898	73476019	.	+	.	ID=exon-272429;Parent=TCONS_00068049;exon_number=2;gene_id=XLOC_025966;transcript_id=TCONS_00068049


### PR DESCRIPTION
Annotation: Ras-GTPase-activating protein-binding-like protein

**Annotator:**  [Marlen Brodbeck](https://orcid.org/0009-0006-6502-2560)
**Gene name:** Ras-GTPase-activating protein-binding-like protein
**Gene nomenclature:** []()
**Source/ NCBI GeneBank ID:** [MT795155.1](https://www.ncbi.nlm.nih.gov/nuccore/MT795155.1)

**Annotated XLOC:** XLOC_025966
**Annotation process:**

- Obtained mRNA sequence from NCBI
- Mapped to P. dum. transcriptome assembly v021 using BLASTn (Jékely Lab): [Results](https://jekelylab.ex.ac.uk/blast/a52af0c0-6cbc-4363-87c9-406e39398e3d#Query_1_hit_1)
- Best hit (TCONS_00068049 XLOC_025966) > blastx on NCBI > confirmed

**Comments:** /