### PR TITLE
Annotate FzCRD-1

### DIFF
--- a/chunks/unplaced.gff3-03
+++ b/chunks/unplaced.gff3-03
@@ -2767,7 +2767,7 @@ scaffold_53	StringTie	transcript	2278444	2278675	.	+	.	ID=TCONS_00129273;Parent=
 scaffold_53	StringTie	exon	2278444	2278675	.	+	.	ID=exon-488626;Parent=TCONS_00129273;exon_number=1;gene_id=XLOC_054234;transcript_id=TCONS_00129273
 scaffold_53	StringTie	transcript	2283040	2283315	.	+	.	ID=TCONS_00129274;Parent=XLOC_054234;gene_id=XLOC_054234;oId=TCONS_00129274;transcript_id=TCONS_00129274;tss_id=TSS104607
 scaffold_53	StringTie	exon	2283040	2283315	.	+	.	ID=exon-488627;Parent=TCONS_00129274;exon_number=1;gene_id=XLOC_054234;transcript_id=TCONS_00129274
-scaffold_53	StringTie	gene	2289240	2344350	.	-	.	ID=XLOC_054283;gene_id=XLOC_054283;oId=TCONS_00129391;transcript_id=TCONS_00129391;tss_id=TSS104701
+scaffold_53	StringTie	gene	2289240	2344350	.	-	.	ID=XLOC_054283;gene_id=XLOC_054283;oId=TCONS_00129391;transcript_id=TCONS_00129391;tss_id=TSS104701;name=FzCRD-1;annotator=SQS/Schneider lab
 scaffold_53	StringTie	transcript	2289240	2344346	.	-	.	ID=TCONS_00129390;Parent=XLOC_054283;gene_id=XLOC_054283;oId=TCONS_00129390;transcript_id=TCONS_00129390;tss_id=TSS104701
 scaffold_53	StringTie	exon	2289240	2290278	.	-	.	ID=exon-489117;Parent=TCONS_00129390;exon_number=1;gene_id=XLOC_054283;transcript_id=TCONS_00129390
 scaffold_53	StringTie	exon	2304043	2304180	.	-	.	ID=exon-489118;Parent=TCONS_00129390;exon_number=2;gene_id=XLOC_054283;transcript_id=TCONS_00129390


### PR DESCRIPTION
Extensive gene model search, and subsequent solid phylogenetic analysis using metazoan gene and nereid gene models. Already on NCBI: GenBank: ALS30893.1 This is one of a number of smaller gene models with a Frizzled-related Cysteine-Rich Domains (CRDs) mostly not deeply evolutionary conserved.