### PR TITLE
Annotate FoxL1

### DIFF
--- a/chunks/scaffold_3.gff3-01
+++ b/chunks/scaffold_3.gff3-01
@@ -3206,7 +3206,7 @@ scaffold_3	StringTie	exon	31879499	31882698	.	-	.	ID=exon-386569;Parent=TCONS_00
 scaffold_3	StringTie	gene	31910238	31915171	.	+	.	ID=XLOC_042371;gene_id=XLOC_042371;oId=TCONS_00103821;transcript_id=TCONS_00103821;tss_id=TSS83779
 scaffold_3	StringTie	transcript	31910238	31915171	.	+	.	ID=TCONS_00103821;Parent=XLOC_042371;gene_id=XLOC_042371;oId=TCONS_00103821;transcript_id=TCONS_00103821;tss_id=TSS83779
 scaffold_3	StringTie	exon	31910238	31915171	.	+	.	ID=exon-400549;Parent=TCONS_00103821;exon_number=1;gene_id=XLOC_042371;transcript_id=TCONS_00103821
-scaffold_3	StringTie	gene	31992074	31995926	.	-	.	ID=XLOC_040881;gene_id=XLOC_040881;oId=TCONS_00100436;transcript_id=TCONS_00100436;tss_id=TSS81108
+scaffold_3	StringTie	gene	31992074	31995926	.	-	.	ID=XLOC_040881;gene_id=XLOC_040881;oId=TCONS_00100436;transcript_id=TCONS_00100436;tss_id=TSS81108;name=FoxL1;annotator=SQS/Schneider lab
 scaffold_3	StringTie	transcript	31992074	31995926	.	-	.	ID=TCONS_00100436;Parent=XLOC_040881;gene_id=XLOC_040881;oId=TCONS_00100436;transcript_id=TCONS_00100436;tss_id=TSS81108
 scaffold_3	StringTie	exon	31992074	31995378	.	-	.	ID=exon-386570;Parent=TCONS_00100436;exon_number=1;gene_id=XLOC_040881;transcript_id=TCONS_00100436
 scaffold_3	StringTie	exon	31995527	31995926	.	-	.	ID=exon-386571;Parent=TCONS_00100436;exon_number=2;gene_id=XLOC_040881;transcript_id=TCONS_00100436


### PR DESCRIPTION
Extensive gene model search in Platynereis and other nereids, and subsequent solid phylogenetic analysis using metazoan gene and nereid gene models of all fox related genes. Nereid annelids (Avir, Pdum) have only one foxL1 gene. Currently not on NCBI. Best hit: forkhead box protein L1-like [Haliotis rufescens]. There is a second gene model XLOC_039413 which encodes the same gene and was also named FoxL1. One of these two models should be removed.