### PR TITLE
Annotation: Histone deacetylase 8 (HDAC8)

### DIFF
--- a/chunks/scaffold_1.gff3-04
+++ b/chunks/scaffold_1.gff3-04
@@ -4332,7 +4332,7 @@ scaffold_1	StringTie	exon	84130147	84130574	.	+	.	ID=exon-104052;Parent=TCONS_00
 scaffold_1	StringTie	gene	84136112	84136697	.	+	.	ID=XLOC_007148;gene_id=XLOC_007148;oId=TCONS_00023182;transcript_id=TCONS_00023182;tss_id=TSS18215
 scaffold_1	StringTie	transcript	84136112	84136697	.	+	.	ID=TCONS_00023182;Parent=XLOC_007148;gene_id=XLOC_007148;oId=TCONS_00023182;transcript_id=TCONS_00023182;tss_id=TSS18215
 scaffold_1	StringTie	exon	84136112	84136697	.	+	.	ID=exon-104053;Parent=TCONS_00023182;exon_number=1;gene_id=XLOC_007148;transcript_id=TCONS_00023182
-scaffold_1	StringTie	gene	84139081	84146044	.	+	.	ID=XLOC_001297;gene_id=XLOC_001297;oId=TCONS_00004654;transcript_id=TCONS_00004654;tss_id=TSS3640
+scaffold_1	StringTie	gene	84139081	84146044	.	+	.	ID=XLOC_001297;gene_id=XLOC_001297;oId=TCONS_00004654;transcript_id=TCONS_00004654;tss_id=TSS3640;name=HDAC8 (Histone deacetylase 8);annotator=Marlen Brodbeck (ORCID:0009-0006-6502-2560) / Jekely lab
 scaffold_1	StringTie	transcript	84139081	84146044	.	+	.	ID=TCONS_00004654;Parent=XLOC_001297;gene_id=XLOC_001297;oId=TCONS_00004654;transcript_id=TCONS_00004654;tss_id=TSS3640
 scaffold_1	StringTie	exon	84139081	84139628	.	+	.	ID=exon-20942;Parent=TCONS_00004654;exon_number=1;gene_id=XLOC_001297;transcript_id=TCONS_00004654
 scaffold_1	StringTie	exon	84141508	84141560	.	+	.	ID=exon-20943;Parent=TCONS_00004654;exon_number=2;gene_id=XLOC_001297;transcript_id=TCONS_00004654


### PR DESCRIPTION
Annotation: Histone deacetylase 8 (HDAC8)

**Annotator:**  [Marlen Brodbeck](https://orcid.org/0009-0006-6502-2560) 
**Gene name:** Histone deacetylase 8 (HDAC8)
**Gene nomenclature:** []()
**Source/ NCBI GeneBank ID:** [MW250944.1](https://www.ncbi.nlm.nih.gov/nuccore/MW250944.1)

**Annotated XLOC:** XLOC_001297
**Annotation process:**

- Obtained mRNA sequence from NCBI
- Mapped to P. dum. transcriptome assembly v021 using BLASTn (Jékely Lab): [Results](https://jekelylab.ex.ac.uk/blast/62a6676e-34ff-4b98-81d5-64ad8f8cd59e)
- Best hit (TCONS_00004654 XLOC_001297) > blastx on NCBI > confirmed

**Comments:** /