### PR TITLE
Annotation: MAP kinase kinase

### DIFF
--- a/chunks/scaffold_5.gff3-01
+++ b/chunks/scaffold_5.gff3-01
@@ -5389,7 +5389,7 @@ scaffold_5	StringTie	exon	37097629	37097719	.	+	.	ID=exon-465503;Parent=TCONS_00
 scaffold_5	StringTie	exon	37098158	37098904	.	+	.	ID=exon-465504;Parent=TCONS_00122672;exon_number=3;gene_id=XLOC_051167;transcript_id=TCONS_00122672
 scaffold_5	StringTie	transcript	37098156	37098773	.	+	.	ID=TCONS_00122673;Parent=XLOC_051167;gene_id=XLOC_051167;oId=TCONS_00122673;transcript_id=TCONS_00122673;tss_id=TSS99177
 scaffold_5	StringTie	exon	37098156	37098773	.	+	.	ID=exon-465505;Parent=TCONS_00122673;exon_number=1;gene_id=XLOC_051167;transcript_id=TCONS_00122673
-scaffold_5	StringTie	gene	37097619	37109306	.	-	.	ID=XLOC_052204;gene_id=XLOC_052204;oId=TCONS_00125732;transcript_id=TCONS_00125733;tss_id=TSS101566
+scaffold_5	StringTie	gene	37097619	37109306	.	-	.	ID=XLOC_052204;gene_id=XLOC_052204;oId=TCONS_00125732;transcript_id=TCONS_00125733;tss_id=TSS101566;name=MAP kinase kinase;annotator=Marlen Brodbeck (ORCID:0009-0006-6502-2560) / Jekely lab
 scaffold_5	StringTie	transcript	37097619	37109306	.	-	.	ID=TCONS_00125733;Parent=XLOC_052204;gene_id=XLOC_052204;oId=TCONS_00125732;transcript_id=TCONS_00125733;tss_id=TSS101566
 scaffold_5	StringTie	exon	37097619	37099277	.	-	.	ID=exon-478095;Parent=TCONS_00125733;exon_number=1;gene_id=XLOC_052204;transcript_id=TCONS_00125733
 scaffold_5	StringTie	exon	37100170	37100309	.	-	.	ID=exon-478096;Parent=TCONS_00125733;exon_number=2;gene_id=XLOC_052204;transcript_id=TCONS_00125733


### PR DESCRIPTION
Annotation: MAP kinase kinase

**Annotator:**  [Marlen Brodbeck](https://orcid.org/0009-0006-6502-2560) 
**Gene name:** MAP kinase kinase
**Gene nomenclature:** []()
**Source/ NCBI GeneBank ID:** [AM114768.1](https://www.ncbi.nlm.nih.gov/nuccore/AM114768.1)

**Annotated XLOC:** XLOC_052204
**Annotation process:**

- Obtained mRNA sequence from NCBI
- Mapped to P. dum. transcriptome assembly v021 using BLASTn (Jékely Lab): [Results](https://jekelylab.ex.ac.uk/blast/246602d9-8e72-4c06-bad0-c42636ae8a46)
- Best hit (TCONS_00125736 XLOC_052204) > blastx on NCBI > confirmed

**Comments:** /