### PR TITLE
Annotate Tubulin epsilon

### DIFF
--- a/chunks/scaffold_20.gff3
+++ b/chunks/scaffold_20.gff3
@@ -2408,7 +2408,7 @@ scaffold_20	StringTie	transcript	5286522	5292467	.	-	.	ID=TCONS_00083512;Parent=
 scaffold_20	StringTie	exon	5286522	5287986	.	-	.	ID=exon-322198;Parent=TCONS_00083512;exon_number=1;gene_id=XLOC_034262;transcript_id=TCONS_00083512
 scaffold_20	StringTie	exon	5288100	5288380	.	-	.	ID=exon-322199;Parent=TCONS_00083512;exon_number=2;gene_id=XLOC_034262;transcript_id=TCONS_00083512
 scaffold_20	StringTie	exon	5292356	5292467	.	-	.	ID=exon-322200;Parent=TCONS_00083512;exon_number=3;gene_id=XLOC_034262;transcript_id=TCONS_00083512
-scaffold_20	StringTie	gene	5289030	5319761	.	-	.	ID=XLOC_034263;gene_id=XLOC_034263;oId=TCONS_00083514;transcript_id=TCONS_00083514;tss_id=TSS67614
+scaffold_20	StringTie	gene	5289030	5319761	.	-	.	ID=XLOC_034263;gene_id=XLOC_034263;oId=TCONS_00083514;transcript_id=TCONS_00083514;tss_id=TSS67614;name=Tubulin epsilon;annotator=SQS/Schneider lab
 scaffold_20	StringTie	transcript	5289030	5319761	.	-	.	ID=TCONS_00083513;Parent=XLOC_034263;gene_id=XLOC_034263;oId=TCONS_00083513;transcript_id=TCONS_00083513;tss_id=TSS67614
 scaffold_20	StringTie	exon	5289030	5289104	.	-	.	ID=exon-322215;Parent=TCONS_00083513;exon_number=1;gene_id=XLOC_034263;transcript_id=TCONS_00083513
 scaffold_20	StringTie	exon	5292993	5293526	.	-	.	ID=exon-322216;Parent=TCONS_00083513;exon_number=2;gene_id=XLOC_034263;transcript_id=TCONS_00083513


### PR DESCRIPTION
Extensive gene model search in Platynereis and other nereids, and subsequent solid phylogenetic analysis using metazoan gene and nereid gene models including all tubulin related genes. Pdum has one epsilon Tubulin. Best Blast hit at NCBI: tubulin epsilon chain-like [Liolophura japonica], a mollusc. Platynereis genome encodes at least 9 alpha tubulin genes (potentially several more), seven beta-tubulin genes (maybe a couple more), one gamma, one delta (missing in this version!), one epsilon, and one zeta tubulin gene.